### PR TITLE
docs: mention the Arch Linux package

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ Install from source:
 ```
 Or download pre-built artifact from release page.
 
+## Distro Packages
+
+<details>
+  <summary>Packaging status</summary>
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/openapi-tui.svg)](https://repology.org/project/openapi-tui/versions)
+
+</details>
+
+### Arch Linux
+
+You can install using `pacman` as follows:
+
+```bash
+❯ pacman -S openapi-tui
+```
+
 # Usage
 ```bash
 ❯ openapi-tui --help


### PR DESCRIPTION
Hey! :bear:

I packaged this awesome project for Arch Linux: https://archlinux.org/packages/extra/x86_64/openapi-tui/

This PR simply updates README.md to mention this package and also adds the repology badge for the other distro packages.

Cheers!
