### PR TITLE
Feat: Implement execute feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,6 +1958,7 @@ dependencies = [
  "tracing-error",
  "tracing-subscriber",
  "tui-input",
+ "tui-prompts",
  "vergen",
 ]
 
@@ -3085,6 +3086,17 @@ checksum = "b3e785f863a3af4c800a2a669d0b64c879b538738e352607e2624d03f868dc01"
 dependencies = [
  "crossterm",
  "unicode-width",
+]
+
+[[package]]
+name = "tui-prompts"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b83b48e255f374d99cf78dc97455db9454a39b5cca103e26e5f9c930210c06"
+dependencies = [
+ "crossterm",
+ "itertools",
+ "ratatui",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ tracing = "0.1.37"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "serde"] }
 tui-input = "0.8.0"
+tui-prompts = "0.3.8"
 
 [build-dependencies]
 vergen = { version = "8.2.6", features = ["build", "git", "gitoxide", "cargo"] }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,1 +1,2 @@
+pub mod schema_editor;
 pub mod schema_viewer;

--- a/src/components/schema_editor.rs
+++ b/src/components/schema_editor.rs
@@ -1,0 +1,45 @@
+mod breadcrumb;
+mod page;
+mod state;
+
+use std::marker::PhantomData;
+
+use ratatui::prelude::*;
+pub use state::{SchemaEditorPageState, SchemaEditorState};
+
+use self::{breadcrumb::render_breadcrumb, page::render_page};
+
+#[derive(Clone, Copy)]
+pub struct SchemaEditor<'a> {
+  _marker: &'a PhantomData<()>,
+}
+
+impl Default for SchemaEditor<'_> {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl SchemaEditor<'_> {
+  pub fn new() -> Self {
+    Self { _marker: &PhantomData }
+  }
+
+  pub fn schema_path(&self) -> Vec<String> {
+    vec![]
+  }
+}
+
+impl<'a> StatefulWidget for SchemaEditor<'a> {
+  type State = SchemaEditorState<'a>;
+
+  fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+    let json = format!("{:?}", state.to_json().map(|j| j.to_string()));
+    Span::raw(json).render(area, buf);
+    let area = area.inner(&Margin::new(0, 1));
+    if let Some((path, state)) = state.page() {
+      render_breadcrumb(area, buf, path);
+      render_page(area, buf, state)
+    }
+  }
+}

--- a/src/components/schema_editor/breadcrumb.rs
+++ b/src/components/schema_editor/breadcrumb.rs
@@ -1,0 +1,14 @@
+use ratatui::prelude::*;
+
+const ARROW: &'static str = "›";
+
+pub fn render_breadcrumb(area: Rect, buf: &mut Buffer, path: Vec<String>) {
+  let mut spans = vec![];
+
+  for p in path {
+    spans.push(Span::raw(ARROW).light_cyan());
+    spans.push(Span::raw(format!(" {p} ")).cyan());
+  }
+
+  Line::from(spans).render(area, buf);
+}

--- a/src/components/schema_editor/page.rs
+++ b/src/components/schema_editor/page.rs
@@ -1,0 +1,38 @@
+use ratatui::prelude::*;
+use tui_prompts::TextPrompt;
+
+use super::state::SchemaEditorPageState;
+
+pub fn render_page(area: Rect, buf: &mut Buffer, state: &SchemaEditorPageState<'_>) {
+  let area = area.inner(&Margin::new(0, 1));
+  let areas = split_layout(area, state.fields.len());
+  for (idx, (key, area)) in state.fields.iter().zip(areas).enumerate() {
+    if area.area() == 0 {
+      continue;
+    }
+
+    if state.selected == idx {
+      if let Some(left) = area.columns().next() {
+        let symbol = if state.inside { symbols::line::VERTICAL } else { symbols::scrollbar::HORIZONTAL.end };
+        Text::styled(symbol, Style::default().dim()).render(left, buf);
+      }
+    }
+
+    let area = area.inner(&Margin::new(2, 0));
+
+    if let Some(value) = state.prompt_states.get(key) {
+      let mut state = value.1.write().unwrap();
+      TextPrompt::from(key.clone()).render(area, buf, &mut state);
+    } else if let Some(_) = state.children.get(key) {
+      Text::from(format!("🗀 {key} ›")).style(Style::default().white()).render(area, buf);
+    }
+  }
+}
+
+pub fn split_layout(area: Rect, properties: usize) -> Vec<Rect> {
+  Layout::default()
+    .direction(Direction::Vertical)
+    .constraints(vec![Constraint::Length(1); properties])
+    .split(area)
+    .to_vec()
+}

--- a/src/components/schema_editor/state.rs
+++ b/src/components/schema_editor/state.rs
@@ -1,0 +1,312 @@
+use std::{
+  collections::BTreeMap,
+  sync::{Arc, RwLock},
+};
+
+use color_eyre::eyre::Result;
+use crossterm::event::{KeyCode, KeyEvent};
+use oas3::{
+  spec::{RefError, SchemaType},
+  Schema,
+};
+use tui_prompts::{State, TextState};
+
+use crate::{action::Action, pages::home::State as GlobalState, tui::EventResponse};
+
+pub enum SchemaEditorPromptType {
+  String,
+  Password,
+  Int,
+  Float,
+  Bool,
+}
+
+pub struct SchemaEditorPageState<'a> {
+  pub prop_name: String,
+
+  pub inside: bool,
+  pub selected: usize,
+  pub fields: Vec<String>,
+  pub prompt_states: BTreeMap<String, (SchemaEditorPromptType, RwLock<TextState<'a>>)>,
+  pub children: BTreeMap<String, SchemaEditorPageState<'a>>,
+}
+
+#[derive(Default)]
+pub struct SchemaEditorState<'a> {
+  pub root: Option<SchemaEditorPageState<'a>>,
+  pub inside: bool,
+}
+
+impl SchemaEditorPageState<'_> {
+  pub fn new(prop_name: String, schema: &Schema, global_state: Arc<RwLock<GlobalState>>) -> Result<Self, RefError> {
+    let mut prompt_states = BTreeMap::new();
+    let mut children = BTreeMap::new();
+    let mut fields = Vec::with_capacity(schema.properties.len());
+
+    for (key, value) in &schema.properties {
+      let value = value.resolve(&global_state.read().unwrap().openapi_spec)?;
+
+      fields.push(key.clone());
+      match value.schema_type {
+        Some(oas3::spec::SchemaType::Object) => {
+          children.insert(key.clone(), SchemaEditorPageState::new(key.clone(), &value, global_state.clone())?);
+        },
+        _ => {
+          let type_ = value.schema_type.unwrap_or(SchemaType::String);
+          let format = value.format.unwrap_or(String::from("string"));
+          let format = match (type_, &format as &str) {
+            (SchemaType::String, "password") => SchemaEditorPromptType::Password,
+            (SchemaType::String, "int32") => SchemaEditorPromptType::Int,
+            (SchemaType::String, "int64") => SchemaEditorPromptType::Int,
+            (SchemaType::String, _) => SchemaEditorPromptType::String,
+
+            (SchemaType::Integer, _) => SchemaEditorPromptType::Int,
+            (SchemaType::Number, _) => SchemaEditorPromptType::Float,
+
+            (SchemaType::Boolean, _) => SchemaEditorPromptType::Float,
+
+            (SchemaType::Array, _) => {
+              log::warn!("Array type on schema editor");
+              SchemaEditorPromptType::String
+            },
+
+            _ => {
+              log::warn!("[SchemaEditor] Cannot match type and format to create a prompt ({type_:?}, {format:?})");
+              SchemaEditorPromptType::String
+            },
+          };
+          let state = RwLock::new(TextState::new());
+          prompt_states.insert(key.clone(), (format, state));
+        },
+      }
+    }
+
+    fields.sort();
+
+    Ok(Self { prop_name, inside: false, selected: 0, fields, prompt_states, children })
+  }
+
+  pub fn handle_key_events(&mut self, key: KeyEvent) -> Result<Option<EventResponse<Action>>> {
+    if self.inside {
+      let Some(field) = self.fields.get(self.selected) else {
+        return Ok(None);
+      };
+      if let Some(prompt_state) = self.prompt_states.get(field) {
+        if matches!(key.code, KeyCode::Esc) {
+          self.inside = false;
+          return Ok(Some(EventResponse::Stop(Action::Render)));
+        }
+        if matches!(key.code, KeyCode::Enter) {
+          self.down();
+        } else {
+          prompt_state.1.write().unwrap().handle_key_event(key);
+        }
+
+        return Ok(Some(EventResponse::Stop(Action::Render)));
+      } else if let Some(children) = self.children.get_mut(field) {
+        let resp = children.handle_key_events(key);
+        if matches!(resp, Ok(Some(EventResponse::Stop(Action::Back)))) {
+          self.inside = false;
+          return Ok(Some(EventResponse::Stop(Action::Render)));
+        }
+
+        return resp;
+      }
+    }
+
+    if matches!(key.code, KeyCode::Esc) {
+      return Ok(Some(EventResponse::Stop(Action::Back)));
+    }
+
+    Ok(None)
+  }
+
+  fn update(&mut self) {
+    let Some(field) = self.fields.get(self.selected) else { return };
+    if let Some(prompt) = self.prompt_states.get_mut(field) {
+      prompt.1.write().unwrap().focus();
+    }
+  }
+
+  pub fn up(&mut self) {
+    if self.fields.is_empty() {
+      return;
+    }
+
+    if self.inside {
+      let Some(field) = self.fields.get(self.selected) else { return };
+      let Some(page) = self.children.get_mut(field) else { return };
+      page.up()
+    } else {
+      self.selected = self.selected.saturating_add(self.fields.len() - 1) % self.fields.len();
+      self.update();
+    }
+  }
+
+  pub fn down(&mut self) {
+    if self.fields.is_empty() {
+      return;
+    }
+
+    if self.inside {
+      let Some(field) = self.fields.get(self.selected) else { return };
+      let Some(page) = self.children.get_mut(field) else {
+        self.selected = self.selected.saturating_add(1) % self.fields.len();
+        self.update();
+        return;
+      };
+      page.down()
+    } else {
+      self.selected = self.selected.saturating_add(1) % self.fields.len();
+      self.update();
+    }
+  }
+
+  pub fn submit(&mut self) {
+    if self.fields.is_empty() {
+      return;
+    }
+
+    if self.inside {
+      let Some(field) = self.fields.get(self.selected) else {
+        return;
+      };
+
+      if let Some(child) = self.children.get_mut(field) {
+        child.submit()
+      }
+    } else {
+      self.inside = true;
+      self.update();
+    }
+  }
+
+  pub fn to_json(&self) -> Result<serde_json::Value> {
+    let mut map = serde_json::Map::new();
+
+    for (k, v) in &self.prompt_states {
+      let val = v.1.read().unwrap();
+      let val = val.value();
+      let val = match v.0 {
+        SchemaEditorPromptType::String => serde_json::Value::String(val.to_string()),
+        SchemaEditorPromptType::Password => serde_json::Value::String(val.to_string()),
+        SchemaEditorPromptType::Int => {
+          val.parse().map(|v| serde_json::Value::Number(v)).unwrap_or(serde_json::Value::Null)
+        },
+        SchemaEditorPromptType::Float => {
+          val.parse().map(|v| serde_json::Value::Number(v)).unwrap_or(serde_json::Value::Null)
+        },
+        SchemaEditorPromptType::Bool => serde_json::Value::Bool(val == "t"),
+      };
+
+      match val {
+        serde_json::Value::String(s) if s.is_empty() => {},
+        serde_json::Value::Null => {},
+        val => {
+          map.insert(k.clone(), val);
+        },
+      }
+    }
+
+    for (k, v) in &self.children {
+      let v = v.to_json()?;
+      if !v.is_null() {
+        map.insert(k.clone(), v);
+      }
+    }
+
+    if map.is_empty() {
+      return Ok(serde_json::Value::Null);
+    }
+
+    Ok(serde_json::Value::Object(map))
+  }
+}
+impl<'a> SchemaEditorPageState<'a> {
+  pub fn page(&self, path: &mut Vec<String>) -> Option<&SchemaEditorPageState<'a>> {
+    let field = self.fields.get(self.selected)?;
+    path.push(self.prop_name.clone());
+
+    if self.inside {
+      if let Some(child) = self.children.get(field) {
+        child.page(path)
+      } else {
+        Some(self)
+      }
+    } else {
+      Some(self)
+    }
+  }
+}
+
+impl SchemaEditorState<'_> {
+  pub fn new(schema: Option<&Schema>, global_state: Arc<RwLock<GlobalState>>) -> Result<Self> {
+    let root = schema.map(|schema| SchemaEditorPageState::new(String::from("root"), schema, global_state));
+    let root = if let Some(root) = root { Some(root?) } else { None };
+    Ok(Self { root, inside: false })
+  }
+
+  pub fn set_schema(&mut self, schema: Schema, global_state: Arc<RwLock<GlobalState>>) -> Result<()> {
+    let root = SchemaEditorPageState::new(String::from("root"), &schema, global_state)?;
+    self.root = Some(root);
+    self.inside = false;
+    Ok(())
+  }
+
+  pub fn clear(&mut self) {
+    self.root = None;
+    self.inside = false;
+  }
+
+  pub fn handle_key_events(&mut self, key: KeyEvent) -> Result<Option<EventResponse<Action>>> {
+    if let Some(root) = self.root.as_mut() {
+      let resp = root.handle_key_events(key);
+
+      if matches!(resp, Ok(Some(EventResponse::Stop(Action::Back)))) {
+        Ok(None)
+      } else {
+        resp
+      }
+    } else {
+      Ok(None)
+    }
+  }
+
+  pub fn up(&mut self) {
+    if let Some(root) = self.root.as_mut() {
+      root.up()
+    }
+  }
+
+  pub fn down(&mut self) {
+    if let Some(root) = self.root.as_mut() {
+      root.down()
+    }
+  }
+
+  pub fn submit(&mut self) {
+    if let Some(root) = self.root.as_mut() {
+      root.submit()
+    }
+  }
+
+  pub fn to_json(&mut self) -> Result<serde_json::Value> {
+    if let Some(root) = self.root.as_mut() {
+      root.to_json()
+    } else {
+      Ok(serde_json::Value::Null)
+    }
+  }
+}
+impl<'a> SchemaEditorState<'a> {
+  pub fn page(&self) -> Option<(Vec<String>, &SchemaEditorPageState<'a>)> {
+    self
+      .root
+      .as_ref()
+      .map(|p| {
+        let mut path = Vec::new();
+        p.page(&mut path).map(|p| (path, p))
+      })
+      .flatten()
+  }
+}

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -236,6 +236,12 @@ impl Page for Home {
   fn handle_key_events(&mut self, key: KeyEvent) -> Result<Option<EventResponse<Action>>> {
     match self.input_mode {
       InputMode::Normal => {
+
+    if let Some(pane) = self.panes.get_mut(self.focused_pane_index) {
+      if let Some(response) = pane.handle_key_events(key)? {
+        return Ok(Some(response));
+      }
+}
         let response = match key.code {
           KeyCode::Right | KeyCode::Char('l') | KeyCode::Char('L') => EventResponse::Stop(Action::FocusNext),
           KeyCode::Left | KeyCode::Char('h') | KeyCode::Char('H') => EventResponse::Stop(Action::FocusPrev),

--- a/src/panes/request.rs
+++ b/src/panes/request.rs
@@ -10,7 +10,7 @@ use ratatui::{
 
 use crate::{
   action::Action,
-  components::schema_viewer::SchemaViewer,
+  components::schema_editor::{SchemaEditor, SchemaEditorState},
   pages::home::State,
   panes::Pane,
   tui::{EventResponse, Frame},
@@ -23,24 +23,26 @@ pub struct RequestType {
 }
 
 #[derive(Default)]
-pub struct RequestPane {
+pub struct RequestPane<'a> {
   focused: bool,
   focused_border_style: Style,
   state: Arc<RwLock<State>>,
 
   schemas: Vec<RequestType>,
   schemas_index: usize,
-  schema_viewer: SchemaViewer,
+  schema_editor: SchemaEditor<'a>,
+  schema_editor_state: SchemaEditorState<'a>,
 }
 
-impl RequestPane {
+impl RequestPane<'_> {
   pub fn new(state: Arc<RwLock<State>>, focused: bool, focused_border_style: Style) -> Self {
     Self {
       focused,
       focused_border_style,
       schemas: Vec::default(),
       schemas_index: 0,
-      schema_viewer: SchemaViewer::from(state.clone()),
+      schema_editor: SchemaEditor::new(),
+      schema_editor_state: SchemaEditorState::new(None, state.clone()).unwrap(),
       state,
     }
   }
@@ -128,15 +130,15 @@ impl RequestPane {
       }
     }
     if let Some(request_type) = self.schemas.get(self.schemas_index) {
-      self.schema_viewer.set(request_type.schema.clone())?;
+      self.schema_editor_state.set_schema(request_type.schema.clone(), self.state.clone())?;
     } else {
-      self.schema_viewer.clear();
+      self.schema_editor_state.clear();
     }
     Ok(())
   }
 
   fn nested_schema_path_line(&self) -> Line {
-    let schema_path = self.schema_viewer.schema_path();
+    let schema_path = self.schema_editor.schema_path();
     if schema_path.is_empty() {
       return Line::default();
     }
@@ -147,7 +149,7 @@ impl RequestPane {
   }
 }
 
-impl Pane for RequestPane {
+impl Pane for RequestPane<'_> {
   fn init(&mut self) -> Result<()> {
     self.init_schema()?;
     Ok(())
@@ -173,8 +175,8 @@ impl Pane for RequestPane {
     }
   }
 
-  fn handle_key_events(&mut self, _key: KeyEvent) -> Result<Option<EventResponse<Action>>> {
-    Ok(None)
+  fn handle_key_events(&mut self, key: KeyEvent) -> Result<Option<EventResponse<Action>>> {
+    self.schema_editor_state.handle_key_events(key)
   }
 
   #[allow(unused_variables)]
@@ -189,20 +191,20 @@ impl Pane for RequestPane {
         self.init_schema()?;
       },
       Action::Down => {
-        self.schema_viewer.down();
+        self.schema_editor_state.down();
       },
       Action::Up => {
-        self.schema_viewer.up();
+        self.schema_editor_state.up();
       },
       Action::Tab(index) if index < self.schemas.len().try_into()? => {
         self.schemas_index = index.try_into()?;
-        self.init_schema()?;
+        // self.init_schema()?;
       },
-      Action::Go => self.schema_viewer.go()?,
+      Action::Submit => self.schema_editor_state.submit(),
       Action::Back => {
-        if let Some(request_type) = self.schemas.get(self.schemas_index) {
-          self.schema_viewer.back(request_type.schema.clone())?;
-        }
+        // if let Some(request_type) = self.schemas.get(self.schemas_index) {
+        // self.schema_editor.back(request_type.schema.clone())?;
+        // }
       },
       _ => {},
     }
@@ -228,7 +230,7 @@ impl Pane for RequestPane {
     let inner_margin: Margin = Margin { horizontal: 1, vertical: 1 };
     let mut inner = inner.inner(&inner_margin);
     inner.height = inner.height.saturating_add(1);
-    self.schema_viewer.render_widget(frame, inner);
+    frame.render_stateful_widget(self.schema_editor, inner, &mut self.schema_editor_state);
 
     frame.render_widget(
       Block::default()


### PR DESCRIPTION
In this pull request I will implement the execute feature. I'm still working on, but now you can see my progress.

For now I already have implement the [body editor](https://github.com/zaghaghi/openapi-tui/blob/7dea5b1c97b5c1c3b0e1a29b357a08c3530a1156/src/components/schema_editor.rs) for serialize in a json and send the request, this body editor could be used (also) to implement an editor for headers, queries and params.

**Todo:**
- [x] Schema editor
- [x] Json serializer
- [ ] Send request
- [ ] Find the way to implement this for websocket
- [ ] Response viewer

**Demo**
![a](https://github.com/zaghaghi/openapi-tui/assets/70247585/b4f6ab91-5a17-4463-936d-3ec884b38c28)