### PR TITLE
Feat: add keybindings for navigation to adjacent tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Then, add `openapi-tui` to your `configuration.nix`
 | `↓`, `j` | Move down in lists |
 | `↑`, `k` | Move up in lists |
 | `1...9` | Move between tabs |
+| `]` | Move to next tab |
+| `[` | Move to previous tab |
 | `f` | Toggle fullscreen pane|
 | `g` | Go in nested items in lists|
 | `/` | Filter apis|

--- a/src/action.rs
+++ b/src/action.rs
@@ -19,6 +19,8 @@ pub enum Action {
   Submit,
   Update,
   Tab(u32),
+  TabNext,
+  TabPrev,
   Go,
   Back,
   ToggleFullScreen,

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -248,6 +248,8 @@ impl Page for Home {
           KeyCode::Char(c) if ('1'..='9').contains(&c) => {
             EventResponse::Stop(Action::Tab(c.to_digit(10).unwrap_or(0) - 1))
           },
+          KeyCode::Char(']') => EventResponse::Stop(Action::TabNext),
+          KeyCode::Char('[') => EventResponse::Stop(Action::TabPrev),
           KeyCode::Char('/') => EventResponse::Stop(Action::FocusFooter),
           _ => {
             return Ok(None);

--- a/src/panes/request.rs
+++ b/src/panes/request.rs
@@ -198,6 +198,15 @@ impl Pane for RequestPane {
         self.schemas_index = index.try_into()?;
         self.init_schema()?;
       },
+      Action::TabNext => {
+        let next_tab_index = self.schemas_index + 1;
+        self.schemas_index = if next_tab_index < self.schemas.len() { next_tab_index } else { 0 };
+        self.init_schema()?;
+      },
+      Action::TabPrev => {
+        self.schemas_index = if self.schemas_index > 0 { self.schemas_index - 1 } else { self.schemas.len() - 1 };
+        self.init_schema()?;
+      },
       Action::Go => self.schema_viewer.go()?,
       Action::Back => {
         if let Some(request_type) = self.schemas.get(self.schemas_index) {

--- a/src/panes/response.rs
+++ b/src/panes/response.rs
@@ -180,6 +180,15 @@ impl Pane for ResponsePane {
         self.schemas_index = index.try_into()?;
         self.init_schema()?;
       },
+      Action::TabNext => {
+        let next_tab_index = self.schemas_index + 1;
+        self.schemas_index = if next_tab_index < self.schemas.len() { next_tab_index } else { 0 };
+        self.init_schema()?;
+      },
+      Action::TabPrev => {
+        self.schemas_index = if self.schemas_index > 0 { self.schemas_index - 1 } else { self.schemas.len() - 1 };
+        self.init_schema()?;
+      },
       Action::Go => self.schema_viewer.go()?,
       Action::Back => {
         if let Some(response_type) = self.schemas.get(self.schemas_index) {


### PR DESCRIPTION
Thank you to useful TUI!
I added keybindings for navigating to the next/previous tab using `]` and `[`.
Of course, I understand that tab navigation can also be done using numeric keys, so there might be some overlap in features. If you think this is a duplicate feature, please feel free to close this pull request!