### PR TITLE
nix: add default package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
   in {
     packages = eachSystem (system: {
       openapi-tui = pkgsFor.${system}.myPackage;
+      default =     pkgsFor.${system}.myPackage;
     });
 
     checks = eachSystem (system: self.packages.${system});


### PR DESCRIPTION
solves nix run error:
$ nix run github:zaghaghi/openapi-tui
error: flake 'github:zaghaghi/openapi-tui' does not provide attribute 'apps.x86_64-linux.default', 'defaultApp.x86_64-linux', 'packages.x86_64-linux.default' or 'defaultPackage.x86_64-linux'