### PR TITLE
feat: add dynamic panel resizing with keyboard shortcuts

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -45,4 +45,6 @@ pub enum Action {
   RemoveHeader(String),
   OpenRequestPayload(String),
   SaveResponsePayload(String),
+  IncreasePanelWidth,
+  DecreasePanelWidth,
 }

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -19,6 +19,7 @@ pub struct Home {
   panes: Vec<Box<dyn Pane>>,
   focused_pane_index: usize,
   fullscreen_pane_index: Option<usize>,
+  left_panel_width: u16,
 }
 
 impl Home {
@@ -38,6 +39,7 @@ impl Home {
 
       focused_pane_index: 0,
       fullscreen_pane_index: None,
+      left_panel_width: 30, // Default to 30% width
     })
   }
 }
@@ -54,7 +56,7 @@ impl Page for Home {
     if let Some(command_tx) = &self.command_tx {
       const ARROW: &str = symbols::scrollbar::HORIZONTAL.end;
       let status_line =
-        format!("[l,h {ARROW} pane movement] [/ {ARROW} api filter] [: {ARROW} commands] [q {ARROW} quit]");
+        format!("[l,h {ARROW} pane movement] [+/- {ARROW} resize panels] [/ {ARROW} api filter] [: {ARROW} commands] [q {ARROW} quit]");
       command_tx.send(Action::StatusLine(status_line))?;
     }
     Ok(())
@@ -101,6 +103,12 @@ impl Page for Home {
       },
       Action::ToggleFullScreen => {
         self.fullscreen_pane_index = self.fullscreen_pane_index.map_or(Some(self.focused_pane_index), |_| None);
+      },
+      Action::IncreasePanelWidth => {
+        self.left_panel_width = (self.left_panel_width + 5).min(80); // Max 80%
+      },
+      Action::DecreasePanelWidth => {
+        self.left_panel_width = (self.left_panel_width.saturating_sub(5)).max(20); // Min 20%
       },
       Action::FocusFooter(..) => {
         if let Some(pane) = self.panes.get_mut(self.focused_pane_index) {
@@ -172,6 +180,8 @@ impl Page for Home {
           KeyCode::Char('[') => EventResponse::Stop(Action::TabPrev),
           KeyCode::Char('/') => EventResponse::Stop(Action::FocusFooter("/".into(), Some(state.active_filter.clone()))),
           KeyCode::Char(':') => EventResponse::Stop(Action::FocusFooter(":".into(), None)),
+          KeyCode::Char('+') | KeyCode::Char('=') => EventResponse::Stop(Action::IncreasePanelWidth),
+          KeyCode::Char('-') => EventResponse::Stop(Action::DecreasePanelWidth),
           _ => {
             return Ok(None);
           },
@@ -189,7 +199,10 @@ impl Page for Home {
     } else {
       let outer_layout = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints(vec![Constraint::Fill(1), Constraint::Fill(3)])
+        .constraints(vec![
+          Constraint::Percentage(self.left_panel_width),
+          Constraint::Percentage(100 - self.left_panel_width),
+        ])
         .split(area);
 
       let left_panes = Layout::default()


### PR DESCRIPTION
I have very long endpoint names in my API, so wanted the ability to resize the panels to make the left one wider.  You can use keyboard shortcuts to resize the panels with this PR.  I used Claude Code, and it did a one-shot solution which I haven't done exhaustive testing on, but looks like it worked and the code changes are minimal.

- Add +/= and - keyboard shortcuts to resize left/right panels
- Left panels (APIs/Tags) can be resized from 20% to 80% width
- Default improved from 25% to 30% for better visibility of long API paths
- Resize in 5% increments for fine control
- Updated status line to show resize shortcuts
- Non-breaking change - all existing functionality preserved

Fixes issue with long API endpoint names being mostly hidden in narrow panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)