### PR TITLE
feat: global request headers via -H/--header

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -42,8 +42,8 @@ pub struct App {
 }
 
 impl App {
-  pub async fn new(input: String) -> Result<Self> {
-    let state = State::from_input(input).await?;
+  pub async fn new(input: String, global_headers: Vec<(String, String)>) -> Result<Self> {
+    let state = State::from_input(input, global_headers).await?;
     let home = Home::new()?;
     let config = Config::new()?;
     let mode = Mode::Home;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,4 +12,12 @@ pub struct Cli {
     help = "Input file or url, in json or yaml format with openapi specification"
   )]
   pub input: String,
+
+  #[arg(
+    short = 'H',
+    long = "header",
+    value_name = "NAME: VALUE",
+    help = "Global header to attach to every request, in `Name: Value` form. May be repeated."
+  )]
+  pub headers: Vec<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,12 +14,21 @@ pub mod utils;
 
 use clap::Parser;
 use cli::Cli;
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{eyre, Result};
 
 use crate::{
   app::App,
   utils::{initialize_logging, initialize_panic_handler},
 };
+
+fn parse_header(raw: &str) -> Result<(String, String)> {
+  let (name, value) = raw.split_once(':').ok_or_else(|| eyre!("invalid header `{raw}`: expected `Name: Value`"))?;
+  let name = name.trim();
+  if name.is_empty() {
+    return Err(eyre!("invalid header `{raw}`: empty name"));
+  }
+  Ok((name.to_string(), value.trim().to_string()))
+}
 
 async fn tokio_main() -> Result<()> {
   initialize_logging()?;
@@ -27,7 +36,8 @@ async fn tokio_main() -> Result<()> {
   initialize_panic_handler()?;
 
   let args = Cli::parse();
-  let mut app = App::new(args.input).await?;
+  let global_headers = args.headers.iter().map(|h| parse_header(h)).collect::<Result<Vec<_>>>()?;
+  let mut app = App::new(args.input, global_headers).await?;
   app.run().await?;
 
   Ok(())

--- a/src/panes/parameter_editor.rs
+++ b/src/panes/parameter_editor.rs
@@ -105,6 +105,14 @@ impl ParameterEditor {
           schema: parameter.schema.clone(),
         });
       });
+
+      for (name, value) in &state.global_headers {
+        if header_items.iter().any(|item: &ParameterItem| item.name.eq_ignore_ascii_case(name)) {
+          continue;
+        }
+        header_items.push(ParameterItem { name: name.clone(), value: Some(value.clone()), ..Default::default() });
+      }
+
       if !path_items.is_empty() {
         self.parameters.push(ParameterTab {
           location: "Path".to_string(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -20,6 +20,7 @@ pub struct State {
   pub responses: HashMap<String, Response>,
   pub pending_operations: HashSet<String>,
   pub spinner_frame: usize,
+  pub global_headers: Vec<(String, String)>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -72,6 +73,7 @@ impl State {
       responses: HashMap::default(),
       pending_operations: HashSet::default(),
       spinner_frame: 0,
+      global_headers: Vec::new(),
     })
   }
 
@@ -104,15 +106,18 @@ impl State {
       responses: HashMap::default(),
       pending_operations: HashSet::default(),
       spinner_frame: 0,
+      global_headers: Vec::new(),
     })
   }
 
-  pub async fn from_input(input: String) -> Result<Self> {
-    if let Ok(url) = reqwest::Url::parse(input.as_str()) {
-      State::from_url(url).await
+  pub async fn from_input(input: String, global_headers: Vec<(String, String)>) -> Result<Self> {
+    let mut state = if let Ok(url) = reqwest::Url::parse(input.as_str()) {
+      State::from_url(url).await?
     } else {
-      State::from_path(input).await
-    }
+      State::from_path(input).await?
+    };
+    state.global_headers = global_headers;
+    Ok(state)
   }
 
   pub fn get_operation(&self, operation_id: Option<String>) -> Option<&OperationItem> {


### PR DESCRIPTION
## Summary
- Adds a repeatable `-H, --header 'Name: Value'` CLI flag for attaching default headers (e.g. `Authorization`) to every request.
- Global headers are merged into each operation's **Header** parameter tab on init, so they remain visible and overridable per call.
- Per-operation headers defined in the OpenAPI spec win on name conflict.

Usage:
```bash
openapi-tui -i examples/petstore.json \
  -H 'Authorization: Bearer xyz' \
  -H 'X-Env: dev'
```

Closes #51

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo test --all-features --workspace` (50 passed)
- [ ] Manual: launch with `-H` flags, open an operation, confirm the headers appear in the Header tab with their values pre-filled and are sent with the request.
- [ ] Manual: spec defines a header with the same name as a `-H` flag — confirm the spec value wins.
- [ ] Manual: malformed `-H` (no colon) — confirm the CLI errors out cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)