### PR TITLE
feat: OpenAPI security schemes (authenticate once per API)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2033,6 +2033,7 @@ name = "openapi-tui"
 version = "0.10.2"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "better-panic",
  "boon",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "serde"] }
 tui-input = "0.15.0"
 ratatui-textarea = "0.8.0"
+base64 = "0.22.1"
 
 [build-dependencies]
 anyhow = "1.0.86"

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ Terminal UI to list, browse and run APIs defined with OpenAPI v3.0 and v3.1 spec
 ❯ openapi-tui --help
 This TUI allows you to list and browse APIs described by the openapi specification.
 
-Usage: openapi-tui --input <PATH>
+Usage: openapi-tui [OPTIONS] --input <PATH>
 
 Options:
-  -i, --input <PATH>  Input file or url, in json or yaml format with openapi specification
-  -h, --help          Print help
-  -V, --version       Print version
+  -i, --input <PATH>          Input file or url, in json or yaml format with openapi specification
+  -H, --header <NAME: VALUE>  Global header to attach to every request, in `Name: Value` form. May be repeated.
+  -h, --help                  Print help
+  -V, --version               Print version
 ```
 
 ## Examples
@@ -29,6 +30,9 @@ Options:
 
 # open remote file
 ❯ openapi-tui -i https://raw.githubusercontent.com/github/rest-api-description/main/descriptions-next/api.github.com/api.github.com.yaml
+
+# attach default headers to every request
+❯ openapi-tui -i examples/petstore.json -H 'Authorization: Bearer xyz' -H 'X-Env: dev'
 ```
 
 
@@ -161,12 +165,14 @@ Then, add `openapi-tui` to your `configuration.nix`
 | `q` | Quit |
 | `request`, `r` | Go to request page|
 | `history` | Request history|
+| `auth` | Open authentication popup to set credentials for `components.securitySchemes` |
 
 # Commands Request Page
 | Command | Description |
 |:--------|:------------|
 | `q` | Quit |
 | `send`, `s` | Send request |
+| `auth` | Open authentication popup to set credentials for `components.securitySchemes` |
 | `query`, `q` | Add or remove query strings. sub-commands are `add` or `rm`. e.g. `query add page` |
 | `header`, `h` | Add or remove headers. sub-commands are `add` or `rm`. e.g. `header add x-api-key` |
 | `request`, `r` | Load request payload. e.g. `request open /home/hamed/payload.json` |

--- a/src/action.rs
+++ b/src/action.rs
@@ -42,6 +42,8 @@ pub enum Action {
   Dial,
   History,
   CloseHistory,
+  Auth,
+  CloseAuth,
   AddQuery(String),
   RemoveQuery(String),
   AddHeader(String),

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,7 @@ use crate::{
   action::Action,
   config::Config,
   pages::{home::Home, phone::Phone, Page},
-  panes::{footer::FooterPane, header::HeaderPane, history::HistoryPane, Pane},
+  panes::{auth::AuthPane, footer::FooterPane, header::HeaderPane, history::HistoryPane, Pane},
   request::Request,
   response::Response,
   state::{InputMode, OperationItemType, State},
@@ -241,6 +241,15 @@ impl App {
             self.popup = Some(Box::new(history_popup));
           },
           Action::CloseHistory => {
+            self.popup = None;
+          },
+          Action::Auth => {
+            self.popup = Some(Box::new(AuthPane::new(&self.state)));
+          },
+          Action::CloseAuth => {
+            if self.state.input_mode == InputMode::Insert {
+              self.state.input_mode = InputMode::Normal;
+            }
             self.popup = None;
           },
           _ => {},

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,236 @@
+use std::collections::BTreeMap;
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use reqwest::header::{HeaderName, HeaderValue, AUTHORIZATION, COOKIE};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApiKeyLocation {
+  Header,
+  Query,
+  Cookie,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthKind {
+  ApiKey { name: String, location: ApiKeyLocation },
+  HttpBearer,
+  HttpBasic,
+  Unsupported(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthScheme {
+  pub name: String,
+  pub kind: AuthKind,
+}
+
+impl AuthKind {
+  pub fn label(&self) -> String {
+    match self {
+      AuthKind::ApiKey { name, location } => {
+        let loc = match location {
+          ApiKeyLocation::Header => "header",
+          ApiKeyLocation::Query => "query",
+          ApiKeyLocation::Cookie => "cookie",
+        };
+        format!("apiKey ({loc} {name})")
+      },
+      AuthKind::HttpBearer => "http bearer".to_string(),
+      AuthKind::HttpBasic => "http basic (user:pass)".to_string(),
+      AuthKind::Unsupported(s) => format!("unsupported: {s}"),
+    }
+  }
+
+  pub fn is_supported(&self) -> bool {
+    !matches!(self, AuthKind::Unsupported(_))
+  }
+}
+
+pub fn parse_security_schemes(raw: &serde_yaml::Value) -> Vec<AuthScheme> {
+  let Some(map) = raw.get("components").and_then(|c| c.get("securitySchemes")).and_then(|s| s.as_mapping()) else {
+    return Vec::new();
+  };
+
+  let mut out = Vec::new();
+  for (k, v) in map {
+    let Some(name) = k.as_str() else { continue };
+    let Some(obj) = v.as_mapping() else { continue };
+    let ty = obj.get("type").and_then(|t| t.as_str()).unwrap_or("");
+    let kind = match ty {
+      "apiKey" => {
+        let key_name = obj.get("name").and_then(|n| n.as_str()).unwrap_or("").to_string();
+        let location = match obj.get("in").and_then(|n| n.as_str()).unwrap_or("header") {
+          "query" => ApiKeyLocation::Query,
+          "cookie" => ApiKeyLocation::Cookie,
+          _ => ApiKeyLocation::Header,
+        };
+        AuthKind::ApiKey { name: key_name, location }
+      },
+      "http" => {
+        let scheme = obj.get("scheme").and_then(|n| n.as_str()).unwrap_or("").to_ascii_lowercase();
+        match scheme.as_str() {
+          "bearer" => AuthKind::HttpBearer,
+          "basic" => AuthKind::HttpBasic,
+          other => AuthKind::Unsupported(format!("http {other}")),
+        }
+      },
+      "oauth2" | "openIdConnect" | "mutualTLS" => AuthKind::Unsupported(ty.to_string()),
+      other => AuthKind::Unsupported(other.to_string()),
+    };
+    out.push(AuthScheme { name: name.to_string(), kind });
+  }
+  out
+}
+
+/// Parse a `security` node (top-level or per-operation) into the list of OR-ed
+/// requirement options. Each option is a map of `scheme_name -> scopes`.
+pub fn parse_security_requirements(value: &serde_yaml::Value) -> Option<Vec<BTreeMap<String, Vec<String>>>> {
+  let arr = value.as_sequence()?;
+  let mut out: Vec<BTreeMap<String, Vec<String>>> = Vec::with_capacity(arr.len());
+  for entry in arr {
+    let Some(m) = entry.as_mapping() else { continue };
+    let mut req = BTreeMap::new();
+    for (k, v) in m {
+      if let Some(name) = k.as_str() {
+        let scopes = v
+          .as_sequence()
+          .map(|seq| seq.iter().filter_map(|s| s.as_str().map(String::from)).collect())
+          .unwrap_or_default();
+        req.insert(name.to_string(), scopes);
+      }
+    }
+    out.push(req);
+  }
+  Some(out)
+}
+
+/// Parse `security` from `serde_json::Value` (used for per-operation entries
+/// that openapi-31 already deserialized).
+pub fn parse_security_requirements_json(
+  value: &[BTreeMap<String, serde_json::Value>],
+) -> Vec<BTreeMap<String, Vec<String>>> {
+  value
+    .iter()
+    .map(|m| {
+      m.iter()
+        .map(|(k, v)| {
+          let scopes = v
+            .as_array()
+            .map(|seq| seq.iter().filter_map(|s| s.as_str().map(String::from)).collect())
+            .unwrap_or_default();
+          (k.clone(), scopes)
+        })
+        .collect()
+    })
+    .collect()
+}
+
+/// Pick the first option whose schemes are ALL present in `values`. Returns the
+/// list of (scheme_name, value) pairs to apply, or `None` if no option matches.
+pub fn select_satisfied_option<'a>(
+  options: &'a [BTreeMap<String, Vec<String>>],
+  values: &std::collections::HashMap<String, String>,
+) -> Option<Vec<&'a String>> {
+  for opt in options {
+    if opt.is_empty() {
+      // Empty requirement = explicit no-auth; treat as satisfied with nothing.
+      return Some(Vec::new());
+    }
+    if opt.keys().all(|name| values.get(name).is_some_and(|v| !v.is_empty())) {
+      return Some(opt.keys().collect());
+    }
+  }
+  None
+}
+
+/// Apply a single resolved scheme to a `reqwest::RequestBuilder`.
+pub fn apply_scheme(request: reqwest::RequestBuilder, scheme: &AuthScheme, value: &str) -> reqwest::RequestBuilder {
+  match &scheme.kind {
+    AuthKind::ApiKey { name, location } => match location {
+      ApiKeyLocation::Header => match (HeaderName::try_from(name.as_str()), HeaderValue::from_str(value)) {
+        (Ok(n), Ok(v)) => request.header(n, v),
+        _ => request,
+      },
+      ApiKeyLocation::Query => request.query(&[(name.as_str(), value)]),
+      ApiKeyLocation::Cookie => match HeaderValue::from_str(&format!("{name}={value}")) {
+        Ok(v) => request.header(COOKIE, v),
+        Err(_) => request,
+      },
+    },
+    AuthKind::HttpBearer => match HeaderValue::from_str(&format!("Bearer {value}")) {
+      Ok(v) => request.header(AUTHORIZATION, v),
+      Err(_) => request,
+    },
+    AuthKind::HttpBasic => {
+      let encoded = BASE64.encode(value.as_bytes());
+      match HeaderValue::from_str(&format!("Basic {encoded}")) {
+        Ok(v) => request.header(AUTHORIZATION, v),
+        Err(_) => request,
+      }
+    },
+    AuthKind::Unsupported(_) => request,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn yaml(src: &str) -> serde_yaml::Value {
+    serde_yaml::from_str(src).unwrap()
+  }
+
+  #[test]
+  fn parses_apikey_and_http_schemes() {
+    let v = yaml(
+      r#"
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+    basicAuth:
+      type: http
+      scheme: basic
+    apiKeyHeader:
+      type: apiKey
+      in: header
+      name: X-API-Key
+    apiKeyQuery:
+      type: apiKey
+      in: query
+      name: api_key
+    oauth:
+      type: oauth2
+"#,
+    );
+    let schemes = parse_security_schemes(&v);
+    assert_eq!(schemes.len(), 5);
+    let by_name: std::collections::HashMap<_, _> = schemes.iter().map(|s| (s.name.as_str(), &s.kind)).collect();
+    assert_eq!(by_name["bearerAuth"], &AuthKind::HttpBearer);
+    assert_eq!(by_name["basicAuth"], &AuthKind::HttpBasic);
+    assert!(matches!(by_name["apiKeyHeader"], AuthKind::ApiKey { location: ApiKeyLocation::Header, .. }));
+    assert!(matches!(by_name["apiKeyQuery"], AuthKind::ApiKey { location: ApiKeyLocation::Query, .. }));
+    assert!(matches!(by_name["oauth"], AuthKind::Unsupported(_)));
+  }
+
+  #[test]
+  fn select_satisfied_picks_first_complete_option() {
+    let options = vec![
+      [("a".to_string(), vec![]), ("b".to_string(), vec![])].into_iter().collect(),
+      [("c".to_string(), vec![])].into_iter().collect(),
+    ];
+    let mut values = std::collections::HashMap::new();
+    values.insert("c".to_string(), "x".to_string());
+    let picked = select_satisfied_option(&options, &values).unwrap();
+    assert_eq!(picked, vec![&"c".to_string()]);
+  }
+
+  #[test]
+  fn empty_requirement_is_explicit_no_auth() {
+    let options: Vec<BTreeMap<String, Vec<String>>> = vec![BTreeMap::new()];
+    let values = std::collections::HashMap::new();
+    let picked = select_satisfied_option(&options, &values).unwrap();
+    assert!(picked.is_empty());
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 pub mod action;
 pub mod app;
+pub mod auth;
 pub mod cli;
 pub mod components;
 pub mod config;

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -131,6 +131,8 @@ impl Page for Home {
             .push(Some(Action::NewCall(state.active_operation().and_then(|op| op.operation.operation_id.clone()))));
         } else if args.eq("history") {
           actions.push(Some(Action::History));
+        } else if args.eq("auth") {
+          actions.push(Some(Action::Auth));
         } else {
           actions.push(Some(Action::TimedStatusLine("unknown command".into(), 1)));
         }

--- a/src/pages/phone.rs
+++ b/src/pages/phone.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
   action::Action,
+  auth,
   config::Config,
   pages::Page,
   panes::{
@@ -67,13 +68,23 @@ impl Phone {
     })
   }
 
-  fn build_request(&self) -> Result<reqwest::Request> {
+  fn build_request(&self, state: &State) -> Result<reqwest::Request> {
     let url = self.panes.iter().fold(self.operation_item.path.clone(), |url, pane| pane.path(url));
     let method = reqwest::Method::from_bytes(self.operation_item.method.as_bytes())?;
-    let request_builder = self
+    let mut request_builder = self
       .panes
       .iter()
       .fold(reqwest::Client::new().request(method, url), |request_builder, pane| pane.reqeust(request_builder));
+
+    if let Some(options) = state.effective_security(&self.operation_item.operation) {
+      if let Some(picked) = auth::select_satisfied_option(&options, &state.auth_values) {
+        for scheme_name in picked {
+          if let (Some(scheme), Some(value)) = (state.auth_scheme(scheme_name), state.auth_values.get(scheme_name)) {
+            request_builder = auth::apply_scheme(request_builder, scheme, value);
+          }
+        }
+      }
+    }
 
     Ok(request_builder.build()?)
   }
@@ -84,6 +95,9 @@ impl Phone {
     }
     if command_args.eq("send") || command_args.eq("s") {
       return Some(Action::Dial);
+    }
+    if command_args.eq("auth") {
+      return Some(Action::Auth);
     }
     if command_args.starts_with("query ") || command_args.starts_with("q ") {
       let command_parts = command_args.split(' ').filter(|item| !item.is_empty()).collect::<Vec<_>>();
@@ -241,7 +255,7 @@ impl Page for Phone {
       Action::Dial => {
         if let Some(request_tx) = &self.request_tx {
           request_tx.send(Request {
-            request: self.build_request()?,
+            request: self.build_request(state)?,
             operation_id: self.operation_item.operation.operation_id.clone().unwrap_or_default(),
           })?;
         }
@@ -256,12 +270,15 @@ impl Page for Phone {
           pane.update(Action::Focus, state)?;
         }
         if let Some(action) = self.handle_commands(args) {
-          if let Action::TimedStatusLine(_, _) = action {
-            actions.push(Some(action));
-          } else {
-            for pane in self.panes.iter_mut() {
-              actions.push(pane.update(action.clone(), state)?);
-            }
+          match action {
+            Action::TimedStatusLine(_, _) | Action::Auth => {
+              actions.push(Some(action));
+            },
+            _ => {
+              for pane in self.panes.iter_mut() {
+                actions.push(pane.update(action.clone(), state)?);
+              }
+            },
           }
         }
       },

--- a/src/panes/auth.rs
+++ b/src/panes/auth.rs
@@ -1,0 +1,168 @@
+use color_eyre::eyre::Result;
+use crossterm::event::{Event, KeyCode, KeyEvent};
+use ratatui::{prelude::*, widgets::*};
+use tui_input::{backend::crossterm::EventHandler, Input};
+
+use crate::{
+  action::Action,
+  panes::Pane,
+  state::{InputMode, State},
+  tui::{EventResponse, Frame},
+};
+
+#[derive(Default)]
+pub struct AuthPane {
+  selected: usize,
+  input: Input,
+  scheme_count: usize,
+}
+
+impl AuthPane {
+  pub fn new(state: &State) -> Self {
+    Self { selected: 0, input: Input::default(), scheme_count: state.auth_schemes.len() }
+  }
+
+  fn mask(value: &str) -> String {
+    if value.is_empty() {
+      String::new()
+    } else if value.len() <= 4 {
+      "•".repeat(value.len())
+    } else {
+      let visible = &value[value.len().saturating_sub(4)..];
+      format!("{}{visible}", "•".repeat(value.len() - 4))
+    }
+  }
+}
+
+impl Pane for AuthPane {
+  fn height_constraint(&self) -> Constraint {
+    Constraint::Fill(3)
+  }
+
+  fn handle_key_events(&mut self, key: KeyEvent, state: &mut State) -> Result<Option<EventResponse<Action>>> {
+    match state.input_mode {
+      InputMode::Normal => {
+        let response = match key.code {
+          KeyCode::Down | KeyCode::Char('j') => EventResponse::Stop(Action::Down),
+          KeyCode::Up | KeyCode::Char('k') => EventResponse::Stop(Action::Up),
+          KeyCode::Esc => EventResponse::Stop(Action::CloseAuth),
+          KeyCode::Enter => EventResponse::Stop(Action::Submit),
+          KeyCode::Char('d') => {
+            if let Some(scheme) = state.auth_schemes.get(self.selected) {
+              state.auth_values.remove(&scheme.name);
+            }
+            EventResponse::Stop(Action::Update)
+          },
+          _ => return Ok(Some(EventResponse::Stop(Action::Noop))),
+        };
+        Ok(Some(response))
+      },
+      InputMode::Insert => match key.code {
+        KeyCode::Enter => Ok(Some(EventResponse::Stop(Action::Submit))),
+        KeyCode::Esc => Ok(Some(EventResponse::Stop(Action::CloseAuth))),
+        _ => {
+          self.input.handle_event(&Event::Key(key));
+          Ok(Some(EventResponse::Stop(Action::Noop)))
+        },
+      },
+      InputMode::Command => Ok(Some(EventResponse::Stop(Action::Noop))),
+    }
+  }
+
+  fn update(&mut self, action: Action, state: &mut State) -> Result<Option<Action>> {
+    match action {
+      Action::Down if self.scheme_count > 0 => {
+        self.selected = (self.selected + 1) % self.scheme_count;
+      },
+      Action::Up if self.scheme_count > 0 => {
+        self.selected = (self.selected + self.scheme_count - 1) % self.scheme_count;
+      },
+      Action::Submit if state.input_mode == InputMode::Normal => {
+        if let Some(scheme) = state.auth_schemes.get(self.selected) {
+          if !scheme.kind.is_supported() {
+            return Ok(Some(Action::TimedStatusLine("scheme type not supported".into(), 2)));
+          }
+          let current = state.auth_values.get(&scheme.name).cloned().unwrap_or_default();
+          self.input = self.input.clone().with_value(current);
+          state.input_mode = InputMode::Insert;
+        }
+      },
+      Action::Submit if state.input_mode == InputMode::Insert => {
+        if let Some(scheme) = state.auth_schemes.get(self.selected) {
+          let value = self.input.value().to_string();
+          if value.is_empty() {
+            state.auth_values.remove(&scheme.name);
+          } else {
+            state.auth_values.insert(scheme.name.clone(), value);
+          }
+        }
+        self.input.reset();
+        state.input_mode = InputMode::Normal;
+      },
+      _ => {},
+    }
+    Ok(None)
+  }
+
+  fn draw(&mut self, frame: &mut Frame<'_>, area: Rect, state: &State) -> Result<()> {
+    frame.render_widget(Clear, area);
+    let inner = area.inner(Margin { horizontal: 1, vertical: 1 });
+    let row_widths = [Constraint::Fill(2), Constraint::Fill(3), Constraint::Fill(3)];
+    let column_widths = Layout::horizontal(row_widths).split(inner);
+
+    let rows = state.auth_schemes.iter().enumerate().map(|(i, scheme)| {
+      let stored = state.auth_values.get(&scheme.name);
+      let value_cell = match (state.input_mode == InputMode::Insert && i == self.selected, stored) {
+        (true, _) => Span::default(),
+        (false, Some(v)) => Span::styled(Self::mask(v), Style::default().fg(Color::LightGreen)),
+        (false, None) => Span::styled("(unset)", Style::default().dim()),
+      };
+      let name_style = if scheme.kind.is_supported() { Style::default() } else { Style::default().dim() };
+      Row::new(vec![
+        Cell::from(Span::styled(scheme.name.clone(), name_style)),
+        Cell::from(Span::styled(scheme.kind.label(), Style::default().fg(Color::LightCyan))),
+        Cell::from(value_cell),
+      ])
+    });
+
+    let table = Table::new(rows, vec![column_widths[0].width, column_widths[1].width, column_widths[2].width])
+      .highlight_symbol(symbols::scrollbar::HORIZONTAL.end)
+      .highlight_spacing(HighlightSpacing::Always)
+      .row_highlight_style(Style::default().add_modifier(Modifier::BOLD));
+    let mut table_state = TableState::default().with_selected(Some(self.selected));
+    frame.render_stateful_widget(table, inner, &mut table_state);
+
+    if state.input_mode == InputMode::Insert {
+      let input_area = Rect {
+        x: inner.x + column_widths[0].width + column_widths[1].width,
+        y: inner.y + self.selected as u16,
+        width: column_widths[2].width,
+        height: 1,
+      };
+      let scroll = self.input.visual_scroll(input_area.width as usize);
+      let input =
+        Paragraph::new(Line::from(vec![Span::styled(self.input.value(), Style::default().fg(Color::LightBlue))]))
+          .scroll((0, scroll as u16));
+      frame.set_cursor_position(Position::new(
+        input_area.x + self.input.visual_cursor().saturating_sub(scroll) as u16,
+        input_area.y,
+      ));
+      frame.render_widget(input, input_area);
+    }
+
+    let title = if state.auth_schemes.is_empty() {
+      " Authentication — no security schemes in spec "
+    } else {
+      " Authentication — [⏎ edit] [d clear] [Esc close] "
+    };
+    frame.render_widget(Block::default().borders(Borders::ALL).title(title), area);
+
+    if state.auth_schemes.is_empty() {
+      frame.render_widget(
+        Paragraph::new("This API does not declare any securitySchemes.").style(Style::default().dim()),
+        inner,
+      );
+    }
+    Ok(())
+  }
+}

--- a/src/panes/mod.rs
+++ b/src/panes/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 
 pub mod address;
 pub mod apis;
+pub mod auth;
 pub mod body_editor;
 pub mod footer;
 pub mod header;

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,12 +1,15 @@
 use std::{
-  collections::{HashMap, HashSet},
+  collections::{BTreeMap, HashMap, HashSet},
   env,
 };
 
 use color_eyre::eyre::Result;
 use openapi_31::v31::{Openapi, Operation, Server};
 
-use crate::response::Response;
+use crate::{
+  auth::{self, AuthScheme},
+  response::Response,
+};
 
 #[derive(Default)]
 pub struct State {
@@ -21,6 +24,9 @@ pub struct State {
   pub pending_operations: HashSet<String>,
   pub spinner_frame: usize,
   pub global_headers: Vec<(String, String)>,
+  pub auth_schemes: Vec<AuthScheme>,
+  pub auth_values: HashMap<String, String>,
+  pub global_security: Option<Vec<BTreeMap<String, Vec<String>>>>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -47,12 +53,9 @@ pub enum InputMode {
 }
 
 impl State {
-  async fn from_path(openapi_path: String) -> Result<Self> {
-    let openapi_spec = tokio::fs::read_to_string(&openapi_path)
-      .await
-      .map(|content| serde_yaml::from_str::<Openapi>(content.as_str()))??;
-
+  fn build(openapi_spec: Openapi, raw: &serde_yaml::Value, openapi_input_source: String) -> Self {
     let openapi_operations = openapi_spec
+      .clone()
       .into_operations()
       .map(|(path, method, operation)| {
         if path.starts_with('/') {
@@ -62,9 +65,13 @@ impl State {
         }
       })
       .collect::<Vec<_>>();
-    Ok(Self {
+
+    let auth_schemes = auth::parse_security_schemes(raw);
+    let global_security = raw.get("security").and_then(auth::parse_security_requirements);
+
+    Self {
       openapi_spec,
-      openapi_input_source: openapi_path,
+      openapi_input_source,
       openapi_operations,
       active_operation_index: 0,
       active_tag_name: None,
@@ -74,40 +81,28 @@ impl State {
       pending_operations: HashSet::default(),
       spinner_frame: 0,
       global_headers: Vec::new(),
-    })
+      auth_schemes,
+      auth_values: HashMap::default(),
+      global_security,
+    }
+  }
+
+  async fn from_path(openapi_path: String) -> Result<Self> {
+    let content = tokio::fs::read_to_string(&openapi_path).await?;
+    let openapi_spec = serde_yaml::from_str::<Openapi>(content.as_str())?;
+    let raw: serde_yaml::Value = serde_yaml::from_str(content.as_str())?;
+    Ok(Self::build(openapi_spec, &raw, openapi_path))
   }
 
   async fn from_url(openapi_url: reqwest::Url) -> Result<Self> {
     let resp: String = reqwest::get(openapi_url.clone()).await?.text().await?;
     let mut openapi_spec = serde_yaml::from_str::<Openapi>(resp.as_str())?;
+    let raw: serde_yaml::Value = serde_yaml::from_str(resp.as_str())?;
     if openapi_spec.servers.is_none() {
       let origin = openapi_url.origin().ascii_serialization();
       openapi_spec.servers = Some(vec![openapi_31::v31::Server::new(format!("{}/", origin))]);
     }
-
-    let openapi_operations = openapi_spec
-      .into_operations()
-      .map(|(path, method, operation)| {
-        if path.starts_with('/') {
-          OperationItem { path, method, operation, r#type: OperationItemType::Path }
-        } else {
-          OperationItem { path, method, operation, r#type: OperationItemType::Webhook }
-        }
-      })
-      .collect::<Vec<_>>();
-    Ok(Self {
-      openapi_spec,
-      openapi_input_source: openapi_url.to_string(),
-      openapi_operations,
-      active_operation_index: 0,
-      active_tag_name: None,
-      active_filter: String::default(),
-      input_mode: InputMode::Normal,
-      responses: HashMap::default(),
-      pending_operations: HashSet::default(),
-      spinner_frame: 0,
-      global_headers: Vec::new(),
-    })
+    Ok(Self::build(openapi_spec, &raw, openapi_url.to_string()))
   }
 
   pub async fn from_input(input: String, global_headers: Vec<(String, String)>) -> Result<Self> {
@@ -118,6 +113,18 @@ impl State {
     };
     state.global_headers = global_headers;
     Ok(state)
+  }
+
+  pub fn effective_security(&self, operation: &Operation) -> Option<Vec<BTreeMap<String, Vec<String>>>> {
+    if let Some(per_op) = &operation.security {
+      Some(auth::parse_security_requirements_json(per_op))
+    } else {
+      self.global_security.clone()
+    }
+  }
+
+  pub fn auth_scheme(&self, name: &str) -> Option<&AuthScheme> {
+    self.auth_schemes.iter().find(|s| s.name == name)
   }
 
   pub fn get_operation(&self, operation_id: Option<String>) -> Option<&OperationItem> {


### PR DESCRIPTION
## Summary
- Adds a `:auth` command opening a popup that lists every `components.securitySchemes` entry from the spec; users supply credentials once and the values are stored in-memory only.
- At request time, the operation's effective security is computed (`operation.security` overrides global). For OR-ed options, the first option whose schemes all have user-supplied values is applied.
- Supported scheme types: `http bearer`, `http basic` (`user:pass`), `apiKey` in header/query/cookie. `oauth2` / `openIdConnect` / `mutualTLS` are shown as `unsupported` for v1.
- `security: []` (explicit no-auth) is honored.

The `openapi-31` crate's `SecurityScheme` only models `type` and `description`, so the raw spec is also parsed once into `serde_yaml::Value` and walked for the missing fields (`name`, `in`, `scheme`).

Try it with `examples/petstore.json` — the popup will list both `petstore_auth` (oauth2, greyed out) and `api_key` (apiKey, editable).

Usage:
1. Launch with any spec.
2. Type `:auth` and press Enter to open the popup.
3. Select a scheme, press Enter to edit, type the value, Enter to save, Esc to close.
4. `d` clears the value for the selected scheme.
5. Send any request — auth is attached automatically.

Closes #48

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo test --all-features --workspace` (53 passed; 3 new auth tests)
- [x] `cargo doc --no-deps --document-private-items --all-features --workspace --examples`
- [ ] Manual: petstore.json — set `api_key`, send `findPetsByStatus`, confirm header is attached.
- [ ] Manual: a spec with bearer auth — set the token, confirm `Authorization: Bearer …` is sent.
- [ ] Manual: a spec with basic auth — set `user:pass`, confirm `Authorization: Basic …` is sent.
- [ ] Manual: per-operation `security: []` — confirm no auth is attached even if values are set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)