### PR TITLE
feat: copy request as curl/httpie via :copy command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e149dc73cd30538307e7ffa2acd3d2221148eaeed4871f246657b1c3eaa1cbd2"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.59.0",
+ "x11rb",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,7 +395,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-link 0.1.0",
 ]
 
 [[package]]
@@ -414,6 +440,15 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "color-eyre"
@@ -602,7 +637,7 @@ dependencies = [
  "futures-core",
  "mio",
  "parking_lot",
- "rustix 1.0.0",
+ "rustix 1.1.4",
  "serde",
  "signal-hook",
  "signal-hook-mio",
@@ -810,6 +845,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,6 +927,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "euclid"
 version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +966,21 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "filedescriptor"
@@ -1101,6 +1167,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1235,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1526,6 +1613,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,9 +1796,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
@@ -1762,9 +1863,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1871,6 +1972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1883,6 +1985,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1977,6 +2089,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,6 +2218,7 @@ name = "openapi-tui"
 version = "0.10.2"
 dependencies = [
  "anyhow",
+ "arboard",
  "base64 0.22.1",
  "better-panic",
  "boon",
@@ -2339,6 +2525,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide 0.8.5",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2368,6 +2567,18 @@ checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -2722,14 +2933,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.0"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8dcd64f141950290e45c99f7710ede1b600297c91818bb30b3667c0f45dc0"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.2",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.59.0",
 ]
 
@@ -3003,6 +3214,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3183,7 +3400,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix 1.0.0",
+ "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
 
@@ -3320,6 +3537,20 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -3895,6 +4126,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4013,6 +4250,12 @@ name = "windows-link"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
@@ -4154,6 +4397,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4270,4 +4530,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.99",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter", "serde"] }
 tui-input = "0.15.0"
 ratatui-textarea = "0.8.0"
 base64 = "0.22.1"
+arboard = "3.6.1"
 
 [build-dependencies]
 anyhow = "1.0.86"

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Then, add `openapi-tui` to your `configuration.nix`
 | `q` | Quit |
 | `send`, `s` | Send request |
 | `auth` | Open authentication popup to set credentials for `components.securitySchemes` |
+| `copy [curl\|httpie]` | Copy the current request to the clipboard. Defaults to `curl`. e.g. `copy curl` |
 | `query`, `q` | Add or remove query strings. sub-commands are `add` or `rm`. e.g. `query add page` |
 | `header`, `h` | Add or remove headers. sub-commands are `add` or `rm`. e.g. `header add x-api-key` |
 | `request`, `r` | Load request payload. e.g. `request open /home/hamed/payload.json` |

--- a/src/action.rs
+++ b/src/action.rs
@@ -52,4 +52,5 @@ pub enum Action {
   SaveResponsePayload(String),
   ApplyJqQuery(String),
   ApplySearch(String),
+  Copy(String),
 }

--- a/src/exporters.rs
+++ b/src/exporters.rs
@@ -1,0 +1,109 @@
+use reqwest::Request;
+
+fn shell_quote(s: &str) -> String {
+  format!("'{}'", s.replace('\'', r"'\''"))
+}
+
+fn body_string(req: &Request) -> Option<String> {
+  let body = req.body()?;
+  let bytes = body.as_bytes()?;
+  Some(String::from_utf8_lossy(bytes).into_owned())
+}
+
+pub fn to_curl(req: &Request) -> String {
+  let mut parts = vec!["curl".to_string()];
+  parts.push("-X".to_string());
+  parts.push(req.method().as_str().to_string());
+  parts.push(shell_quote(req.url().as_str()));
+
+  for (name, value) in req.headers() {
+    let v = value.to_str().unwrap_or("");
+    parts.push("-H".to_string());
+    parts.push(shell_quote(&format!("{}: {v}", name.as_str())));
+  }
+
+  if let Some(body) = body_string(req) {
+    parts.push("--data-raw".to_string());
+    parts.push(shell_quote(&body));
+  }
+
+  parts.join(" ")
+}
+
+pub fn to_httpie(req: &Request) -> String {
+  let body = body_string(req);
+
+  let mut parts = Vec::new();
+  if body.is_some() {
+    // httpie reads request body from stdin when piped.
+    parts.push(format!("echo {} |", shell_quote(body.as_deref().unwrap_or(""))));
+  }
+  parts.push("http".to_string());
+  parts.push(req.method().as_str().to_string());
+  parts.push(shell_quote(req.url().as_str()));
+
+  for (name, value) in req.headers() {
+    let v = value.to_str().unwrap_or("");
+    parts.push(shell_quote(&format!("{}:{v}", name.as_str())));
+  }
+
+  parts.join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+  use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+
+  use super::*;
+
+  fn build(method: reqwest::Method, url: &str, headers: HeaderMap, body: Option<&[u8]>) -> Request {
+    let mut req = reqwest::Client::new().request(method, url).headers(headers);
+    if let Some(b) = body {
+      req = req.body(b.to_vec());
+    }
+    req.build().unwrap()
+  }
+
+  fn auth_headers() -> HeaderMap {
+    let mut h = HeaderMap::new();
+    h.insert(AUTHORIZATION, HeaderValue::from_static("Bearer tok"));
+    h.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    h
+  }
+
+  #[test]
+  fn curl_get_no_body() {
+    let req = build(reqwest::Method::GET, "https://api.example.com/v1/pets?limit=2", auth_headers(), None);
+    let out = to_curl(&req);
+    assert!(out.starts_with("curl -X GET 'https://api.example.com/v1/pets?limit=2'"));
+    assert!(out.contains("-H 'authorization: Bearer tok'"));
+    assert!(out.contains("-H 'content-type: application/json'"));
+    assert!(!out.contains("--data-raw"));
+  }
+
+  #[test]
+  fn curl_post_with_body_escapes_quote() {
+    let req =
+      build(reqwest::Method::POST, "https://api.example.com/v1/pets", auth_headers(), Some(br#"{"name":"O'Reilly"}"#));
+    let out = to_curl(&req);
+    assert!(out.contains("-X POST"));
+    assert!(out.contains(r#"--data-raw '{"name":"O'\''Reilly"}'"#));
+  }
+
+  #[test]
+  fn httpie_get_no_body() {
+    let req = build(reqwest::Method::GET, "https://api.example.com/v1/pets", auth_headers(), None);
+    let out = to_httpie(&req);
+    assert!(out.starts_with("http GET 'https://api.example.com/v1/pets'"));
+    assert!(out.contains("'authorization:Bearer tok'"));
+    assert!(!out.contains("echo"));
+  }
+
+  #[test]
+  fn httpie_post_pipes_body() {
+    let req =
+      build(reqwest::Method::POST, "https://api.example.com/v1/pets", auth_headers(), Some(br#"{"name":"Rex"}"#));
+    let out = to_httpie(&req);
+    assert!(out.starts_with("echo '{\"name\":\"Rex\"}' | http POST"));
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ pub mod auth;
 pub mod cli;
 pub mod components;
 pub mod config;
+pub mod exporters;
 pub mod formatters;
 pub mod pages;
 pub mod panes;

--- a/src/pages/phone.rs
+++ b/src/pages/phone.rs
@@ -9,6 +9,7 @@ use crate::{
   action::Action,
   auth,
   config::Config,
+  exporters,
   pages::Page,
   panes::{
     address::AddressPane, body_editor::BodyEditor, parameter_editor::ParameterEditor, response_viewer::ResponseViewer,
@@ -99,6 +100,14 @@ impl Phone {
     if command_args.eq("auth") {
       return Some(Action::Auth);
     }
+    if let Some(rest) = command_args.strip_prefix("copy") {
+      let fmt = rest.trim();
+      let fmt = if fmt.is_empty() { "curl" } else { fmt };
+      if fmt == "curl" || fmt == "httpie" {
+        return Some(Action::Copy(fmt.to_string()));
+      }
+      return Some(Action::TimedStatusLine("invalid format. supported: curl, httpie".into(), 3));
+    }
     if command_args.starts_with("query ") || command_args.starts_with("q ") {
       let command_parts = command_args.split(' ').filter(|item| !item.is_empty()).collect::<Vec<_>>();
       if command_parts.len() == 3 {
@@ -150,7 +159,7 @@ impl Phone {
       return Some(Action::ApplySearch(String::new()));
     }
     Some(Action::TimedStatusLine(
-      "unknown command. available commands are: send, query, header, request, response, jq, search".into(),
+      "unknown command. available: send, auth, copy, query, header, request, response, jq, search".into(),
       3,
     ))
   }
@@ -260,6 +269,19 @@ impl Page for Phone {
           })?;
         }
       },
+      Action::Copy(ref format) => {
+        let request = self.build_request(state)?;
+        let rendered = match format.as_str() {
+          "curl" => exporters::to_curl(&request),
+          "httpie" => exporters::to_httpie(&request),
+          _ => return Ok(Some(Action::TimedStatusLine("unknown copy format".into(), 2))),
+        };
+        let msg = match arboard::Clipboard::new().and_then(|mut cb| cb.set_text(rendered)) {
+          Ok(()) => format!("copied request as {format}"),
+          Err(e) => format!("clipboard unavailable: {e}"),
+        };
+        actions.push(Some(Action::TimedStatusLine(msg, 2)));
+      },
       Action::FocusFooter(..) => {
         if let Some(pane) = self.panes.get_mut(self.focused_pane_index) {
           actions.push(pane.update(Action::UnFocus, state)?);
@@ -271,7 +293,7 @@ impl Page for Phone {
         }
         if let Some(action) = self.handle_commands(args) {
           match action {
-            Action::TimedStatusLine(_, _) | Action::Auth => {
+            Action::TimedStatusLine(_, _) | Action::Auth | Action::Copy(_) => {
               actions.push(Some(action));
             },
             _ => {


### PR DESCRIPTION
## Summary
- Adds `:copy curl` and `:copy httpie` commands on the request page that render the currently-built request and place it on the system clipboard via `arboard` (added as a dependency).
- Bare `:copy` defaults to `curl`.
- The rendered output uses `Phone::build_request(&state)`, so it contains exactly what `:send` would transmit — method, URL with query parameters, all headers (including global `-H` headers and any auth injected from `:auth`), and the body.
- A brief status-line message confirms the copy; if the clipboard backend is unavailable (e.g. headless Linux) the error is surfaced rather than silently dropped.
- httpie output pipes the body via `echo '...' | http METHOD URL ...` so multi-line / arbitrary payloads round-trip safely.
- Single-quote escaping (`'\''`) handles JSON bodies like `{"name":"O'Reilly"}`.

Closes #45

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo test --all-features --workspace` (57 passed; 4 new exporter tests)
- [x] `cargo doc --no-deps --document-private-items --all-features --workspace --examples`
- [ ] Manual: `:copy curl` on a GET request, paste in a terminal, confirm it returns the same response.
- [ ] Manual: `:copy curl` on a POST with a JSON body containing single quotes — confirm the pasted command works.
- [ ] Manual: `:copy httpie` on a GET and POST — confirm `http` and `echo ... | http` forms work.
- [ ] Manual: `:copy curl` after setting `:auth` for a bearer scheme — confirm `Authorization: Bearer ...` is in the curl output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)