### PR TITLE
fix: respect terminal foreground color (legible on light themes)

### DIFF
--- a/src/panes/address.rs
+++ b/src/panes/address.rs
@@ -108,7 +108,7 @@ impl Pane for AddressPane {
               Style::default().fg(Self::method_color(operation_item.method.as_str())),
             ),
             Span::styled(base_url, Style::default().fg(Color::DarkGray)),
-            Span::styled(&operation_item.path, Style::default().fg(Color::White)),
+            Span::raw(&operation_item.path),
           ])),
           OperationItemType::Webhook => Paragraph::new(Line::from(vec![
             Span::styled("EVENT ", Style::default().fg(Color::LightMagenta)),
@@ -116,7 +116,7 @@ impl Pane for AddressPane {
               format!("{} ", operation_item.method.as_str()),
               Style::default().fg(Self::method_color(operation_item.method.as_str())),
             ),
-            Span::styled(&operation_item.path, Style::default().fg(Color::White)),
+            Span::raw(&operation_item.path),
           ])),
         },
         inner,

--- a/src/panes/apis.rs
+++ b/src/panes/apis.rs
@@ -113,7 +113,7 @@ impl Pane for ApisPane {
             OperationItemType::Webhook => Color::LightMagenta,
           },
         ),
-        Span::styled(format!(" {:7}", operation_item.path), Color::White),
+        Span::raw(format!(" {:7}", operation_item.path)),
       ]))
     });
 

--- a/src/panes/request.rs
+++ b/src/panes/request.rs
@@ -234,10 +234,7 @@ impl Pane for RequestPane {
         .border_style(self.border_style())
         .border_type(self.border_type())
         .title_bottom(
-          self
-            .nested_schema_path_line()
-            .style(Style::default().fg(Color::White).dim().add_modifier(Modifier::ITALIC))
-            .left_aligned(),
+          self.nested_schema_path_line().style(Style::default().dim().add_modifier(Modifier::ITALIC)).left_aligned(),
         ),
       area,
     );

--- a/src/panes/response.rs
+++ b/src/panes/response.rs
@@ -217,10 +217,7 @@ impl Pane for ResponsePane {
         .border_style(self.border_style())
         .border_type(self.border_type())
         .title_bottom(
-          self
-            .nested_schema_path_line()
-            .style(Style::default().fg(Color::White).dim().add_modifier(Modifier::ITALIC))
-            .left_aligned(),
+          self.nested_schema_path_line().style(Style::default().dim().add_modifier(Modifier::ITALIC)).left_aligned(),
         ),
       area,
     );


### PR DESCRIPTION
## Summary

Several `Span`s hard-coded `Color::White` as their foreground, which overrode the terminal's default and rendered as invisible white-on-white on light themes (issue #44 — paths in the API list disappeared on a white-background terminal).

Drop the `Color::White` overrides so these spans inherit the terminal default. Readable on both light and dark themes:

- `src/panes/apis.rs` — API path text in the operations list (the reported case)
- `src/panes/address.rs` — operation path in the address pane (Path + Webhook variants)
- `src/panes/request.rs` — italic schema-path footer
- `src/panes/response.rs` — italic schema-path footer

`dim()` and `italic` modifiers are preserved where present.

Closes #44

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo test --all-features --workspace` (57 passed)
- [x] `cargo doc --no-deps --document-private-items --all-features --workspace --examples`
- [ ] Manual: launch with a light-background terminal — confirm paths in the API list are visible.
- [ ] Manual: launch with a dark-background terminal — confirm no visual regression (paths still readable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)