### PR TITLE
feat: help popup showing keys and commands (?)

### DIFF
--- a/.config/config.json5
+++ b/.config/config.json5
@@ -4,7 +4,8 @@
       "<q>": "Quit", // Quit the application
       "<Ctrl-d>": "Quit", // Another way to quit
       "<Ctrl-c>": "Quit", // Yet another way to quit
-      "<Ctrl-z>": "Suspend" // Suspend the application
+      "<Ctrl-z>": "Suspend", // Suspend the application
+      "<?>": "Help" // Show help popup with keys and commands
     },
   }
 }

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Then, add `openapi-tui` to your `configuration.nix`
 | `q` | Quit|
 | `/` | Filter apis|
 | `:` | Run commands|
+| `?` | Show help popup with keys and commands |
 | `Backspace`, `b` | Get out of nested items in lists|
 
 # Commands Main Page
@@ -166,6 +167,7 @@ Then, add `openapi-tui` to your `configuration.nix`
 | `request`, `r` | Go to request page|
 | `history` | Request history|
 | `auth` | Open authentication popup to set credentials for `components.securitySchemes` |
+| `help` | Show help popup with keys and commands |
 
 # Commands Request Page
 | Command | Description |
@@ -174,6 +176,7 @@ Then, add `openapi-tui` to your `configuration.nix`
 | `send`, `s` | Send request |
 | `auth` | Open authentication popup to set credentials for `components.securitySchemes` |
 | `copy [curl\|httpie]` | Copy the current request to the clipboard. Defaults to `curl`. e.g. `copy curl` |
+| `help` | Show help popup with keys and commands |
 | `query`, `q` | Add or remove query strings. sub-commands are `add` or `rm`. e.g. `query add page` |
 | `header`, `h` | Add or remove headers. sub-commands are `add` or `rm`. e.g. `header add x-api-key` |
 | `request`, `r` | Load request payload. e.g. `request open /home/hamed/payload.json` |

--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ Then, add `openapi-tui` to your `configuration.nix`
 - [X] JQ filter for JSON responses
 - [X] Text search in response body
 - [X] Request progress bar
+- [X] Display Key Mappings in Popup
 
 # Backlog
 - [ ] Schema Types (openapi-31)
-- [ ] Display Key Mappings in Popup
 - [ ] Read Spec from STDIN 

--- a/src/action.rs
+++ b/src/action.rs
@@ -15,6 +15,7 @@ pub enum Action {
   Refresh,
   Error(String),
   Help,
+  CloseHelp,
   FocusNext,
   FocusPrev,
   Focus,

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,7 @@ use crate::{
   action::Action,
   config::Config,
   pages::{home::Home, phone::Phone, Page},
-  panes::{auth::AuthPane, footer::FooterPane, header::HeaderPane, history::HistoryPane, Pane},
+  panes::{auth::AuthPane, footer::FooterPane, header::HeaderPane, help::HelpPane, history::HistoryPane, Pane},
   request::Request,
   response::Response,
   state::{InputMode, OperationItemType, State},
@@ -252,6 +252,12 @@ impl App {
             }
             self.popup = None;
           },
+          Action::Help => {
+            self.popup = Some(Box::new(HelpPane::new()));
+          },
+          Action::CloseHelp => {
+            self.popup = None;
+          },
           _ => {},
         }
 
@@ -326,7 +332,7 @@ impl App {
     if let Some(popup) = &mut self.popup {
       let popup_vertical_layout =
         Layout::vertical(vec![Constraint::Fill(1), popup.height_constraint(), Constraint::Fill(1)]).split(frame.area());
-      let popup_layout = Layout::horizontal(vec![Constraint::Fill(1), Constraint::Fill(1), Constraint::Fill(1)])
+      let popup_layout = Layout::horizontal(vec![Constraint::Fill(1), popup.width_constraint(), Constraint::Fill(1)])
         .split(popup_vertical_layout[1]);
       popup.draw(frame, popup_layout[1], &self.state)?;
     }

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -24,7 +24,7 @@ pub struct Home {
 impl Home {
   fn default_status_line() -> String {
     const ARROW: &str = symbols::scrollbar::HORIZONTAL.end;
-    format!("[l,h {ARROW} pane movement] [/ {ARROW} api filter] [: {ARROW} commands] [q {ARROW} quit]")
+    format!("[l,h {ARROW} pane movement] [/ {ARROW} api filter] [: {ARROW} commands] [? {ARROW} help] [q {ARROW} quit]")
   }
 
   pub fn new() -> Result<Self> {

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -133,6 +133,8 @@ impl Page for Home {
           actions.push(Some(Action::History));
         } else if args.eq("auth") {
           actions.push(Some(Action::Auth));
+        } else if args.eq("help") {
+          actions.push(Some(Action::Help));
         } else {
           actions.push(Some(Action::TimedStatusLine("unknown command".into(), 1)));
         }

--- a/src/pages/phone.rs
+++ b/src/pages/phone.rs
@@ -46,7 +46,7 @@ pub trait RequestPane: Pane + RequestBuilder {}
 impl Phone {
   fn default_status_line() -> String {
     const ARROW: &str = symbols::scrollbar::HORIZONTAL.end;
-    format!("[⏎ {ARROW} edit mode/execute request] [1-9 {ARROW} select items] [ESC {ARROW} close] [q {ARROW} quit]")
+    format!("[⏎ {ARROW} edit mode/execute request] [1-9 {ARROW} select items] [? {ARROW} help] [ESC {ARROW} close] [q {ARROW} quit]")
   }
 
   pub fn new(operation_item: OperationItem, request_tx: UnboundedSender<Request>, _state: &State) -> Result<Self> {

--- a/src/pages/phone.rs
+++ b/src/pages/phone.rs
@@ -100,6 +100,9 @@ impl Phone {
     if command_args.eq("auth") {
       return Some(Action::Auth);
     }
+    if command_args.eq("help") {
+      return Some(Action::Help);
+    }
     if let Some(rest) = command_args.strip_prefix("copy") {
       let fmt = rest.trim();
       let fmt = if fmt.is_empty() { "curl" } else { fmt };
@@ -293,7 +296,7 @@ impl Page for Phone {
         }
         if let Some(action) = self.handle_commands(args) {
           match action {
-            Action::TimedStatusLine(_, _) | Action::Auth | Action::Copy(_) => {
+            Action::TimedStatusLine(_, _) | Action::Auth | Action::Help | Action::Copy(_) => {
               actions.push(Some(action));
             },
             _ => {

--- a/src/panes/help.rs
+++ b/src/panes/help.rs
@@ -1,0 +1,171 @@
+use color_eyre::eyre::Result;
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{prelude::*, widgets::*};
+
+use crate::{
+  action::Action,
+  panes::Pane,
+  state::{InputMode, State},
+  tui::{EventResponse, Frame},
+};
+
+struct Section {
+  title: &'static str,
+  rows: &'static [(&'static str, &'static str)],
+}
+
+const SECTIONS: &[Section] = &[
+  Section {
+    title: "Navigation",
+    rows: &[
+      ("→, l", "Move to next pane"),
+      ("←, h", "Move to previous pane"),
+      ("↓, j", "Move down in lists"),
+      ("↑, k", "Move up in lists"),
+      ("1…9", "Select tab by number"),
+      ("]", "Next tab"),
+      ("[", "Previous tab"),
+      ("g", "Go into nested item / definition"),
+      ("Backspace, b", "Back out of nested item"),
+      (",  /  .", "Previous / next schema variant"),
+      ("a", "Toggle annotated/YAML schema view"),
+      ("f", "Toggle fullscreen pane"),
+      ("Enter", "Submit / edit / execute"),
+      ("Esc", "Cancel / close popup / exit edit mode"),
+    ],
+  },
+  Section {
+    title: "Global",
+    rows: &[
+      ("?", "Show this help"),
+      ("/", "Filter APIs"),
+      (":", "Run a command"),
+      ("q", "Quit"),
+      ("Ctrl+C, Ctrl+D", "Quit"),
+      ("Ctrl+Z", "Suspend"),
+    ],
+  },
+  Section {
+    title: "Commands — Main page",
+    rows: &[
+      (":q", "Quit"),
+      (":request, :r", "Open request page for selected operation"),
+      (":history", "Open request history popup"),
+      (":auth", "Open authentication popup"),
+      (":help", "Show this help"),
+    ],
+  },
+  Section {
+    title: "Commands — Request page",
+    rows: &[
+      (":q", "Quit"),
+      (":send, :s", "Send the request"),
+      (":auth", "Open authentication popup"),
+      (":copy [curl|httpie]", "Copy request to clipboard (default: curl)"),
+      (":query add|rm <name>", "Add or remove a query parameter"),
+      (":header add|rm <name>", "Add or remove a header"),
+      (":request open <path>", "Load request payload from file"),
+      (":response save <path>", "Save response payload to file"),
+      (":jq <expr>", "Filter JSON response with jq (empty clears)"),
+      (":search <term>", "Search response body (empty clears)"),
+      (":help", "Show this help"),
+    ],
+  },
+];
+
+#[derive(Default)]
+pub struct HelpPane {
+  scroll: u16,
+}
+
+impl HelpPane {
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  fn lines(&self) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let key_width = SECTIONS.iter().flat_map(|s| s.rows.iter()).map(|(k, _)| k.chars().count()).max().unwrap_or(20);
+
+    for (idx, section) in SECTIONS.iter().enumerate() {
+      if idx > 0 {
+        lines.push(Line::from(""));
+      }
+      lines.push(Line::from(Span::styled(
+        section.title,
+        Style::default().fg(Color::LightCyan).add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+      )));
+      for (key, desc) in section.rows {
+        lines.push(Line::from(vec![
+          Span::styled(format!("  {key:<key_width$}  "), Style::default().fg(Color::LightYellow)),
+          Span::raw(*desc),
+        ]));
+      }
+    }
+    lines
+  }
+
+  fn total_lines(&self) -> u16 {
+    let count: usize = SECTIONS.iter().map(|s| s.rows.len() + 1).sum::<usize>() + SECTIONS.len().saturating_sub(1);
+    count as u16
+  }
+}
+
+impl Pane for HelpPane {
+  fn height_constraint(&self) -> Constraint {
+    Constraint::Fill(5)
+  }
+
+  fn width_constraint(&self) -> Constraint {
+    Constraint::Fill(3)
+  }
+
+  fn handle_key_events(&mut self, key: KeyEvent, state: &mut State) -> Result<Option<EventResponse<Action>>> {
+    if state.input_mode != InputMode::Normal {
+      return Ok(Some(EventResponse::Stop(Action::Noop)));
+    }
+    let response = match key.code {
+      KeyCode::Down | KeyCode::Char('j') => EventResponse::Stop(Action::Down),
+      KeyCode::Up | KeyCode::Char('k') => EventResponse::Stop(Action::Up),
+      KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => EventResponse::Stop(Action::CloseHelp),
+      _ => return Ok(Some(EventResponse::Stop(Action::Noop))),
+    };
+    Ok(Some(response))
+  }
+
+  fn update(&mut self, action: Action, _state: &mut State) -> Result<Option<Action>> {
+    match action {
+      Action::Down => {
+        self.scroll = self.scroll.saturating_add(1);
+      },
+      Action::Up => {
+        self.scroll = self.scroll.saturating_sub(1);
+      },
+      _ => {},
+    }
+    Ok(None)
+  }
+
+  fn draw(&mut self, frame: &mut Frame<'_>, area: Rect, _state: &State) -> Result<()> {
+    frame.render_widget(Clear, area);
+    let inner = area.inner(Margin { horizontal: 2, vertical: 1 });
+
+    let total = self.total_lines();
+    let max_scroll = total.saturating_sub(inner.height);
+    if self.scroll > max_scroll {
+      self.scroll = max_scroll;
+    }
+
+    let paragraph = Paragraph::new(self.lines()).scroll((self.scroll, 0));
+    frame.render_widget(paragraph, inner);
+
+    frame.render_widget(
+      Block::default()
+        .borders(Borders::ALL)
+        .title(" Help — keys & commands ")
+        .title_bottom(Line::from(" [j,k scroll] [Esc / q / ? close] ").right_aligned()),
+      area,
+    );
+    Ok(())
+  }
+}

--- a/src/panes/mod.rs
+++ b/src/panes/mod.rs
@@ -14,6 +14,7 @@ pub mod auth;
 pub mod body_editor;
 pub mod footer;
 pub mod header;
+pub mod help;
 pub mod history;
 pub mod parameter_editor;
 pub mod request;
@@ -27,6 +28,10 @@ pub trait Pane {
   }
 
   fn height_constraint(&self) -> Constraint;
+
+  fn width_constraint(&self) -> Constraint {
+    Constraint::Fill(1)
+  }
 
   fn handle_events(&mut self, event: Event, state: &mut State) -> Result<Option<EventResponse<Action>>> {
     let r = match event {


### PR DESCRIPTION
## Summary

Press `?` (or run `:help`) to open a centered popup listing every keybinding and slash-command in the app, grouped into:

- **Navigation** — pane focus, scrolling, tabs, schema variant, fullscreen, submit/cancel.
- **Global** — `?`, `/`, `:`, quit, suspend.
- **Commands — Main page** — `:request`, `:history`, `:auth`, `:help`, etc.
- **Commands — Request page** — `:send`, `:auth`, `:copy`, `:query`, `:header`, `:request open`, `:response save`, `:jq`, `:search`, `:help`.

Esc / q / ? closes the popup; j/k scroll if the list overflows the popup height.

## Notable details

- Uses the previously-unused `Action::Help`; adds a companion `Action::CloseHelp`.
- `?` is registered in `.config/config.json5` for the `Home` mode, so it works on both the API browser and the request page.
- The `Pane` trait gains a `width_constraint()` with a default of `Fill(1)` (matching today's behavior). `HelpPane` overrides to `Fill(3)` so the popup spans 3/5 of screen width — the existing History/Auth popups are unchanged.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo test --all-features --workspace` (57 passed)
- [x] `cargo doc --no-deps --document-private-items --all-features --workspace --examples`
- [ ] Manual: press `?` from the main page — popup opens.
- [ ] Manual: press `?` from the request page — popup opens.
- [ ] Manual: open popup, press j/k to scroll, press Esc/q/? to close.
- [ ] Manual: confirm History and Auth popups still render at their old width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)