### PR TITLE
fix: skip unresolvable request parameter and body refs instead of panicking

### DIFF
--- a/src/panes/parameter_editor.rs
+++ b/src/panes/parameter_editor.rs
@@ -88,23 +88,29 @@ impl ParameterEditor {
       let mut header_items = vec![];
       let mut cookie_items = vec![];
 
-      self.operation_item.operation.parameters.iter().flatten().for_each(|parameter_or_ref| {
-        let parameter = parameter_or_ref.resolve(&state.openapi_spec).unwrap();
-        let value =
-          parameter.schema.clone().and_then(|schema| schema.get("default").map(|default| default.to_string()));
-        match parameter.r#in {
-          In::Query => &mut query_items,
-          In::Header => &mut header_items,
-          In::Path => &mut path_items,
-          In::Cookie => &mut cookie_items,
-        }
-        .push(ParameterItem {
-          name: parameter.name.clone(),
-          value,
-          required: parameter.required.unwrap_or(false),
-          schema: parameter.schema.clone(),
+      self
+        .operation_item
+        .operation
+        .parameters
+        .iter()
+        .flatten()
+        .filter_map(|parameter_or_ref| parameter_or_ref.resolve(&state.openapi_spec).ok())
+        .for_each(|parameter| {
+          let value =
+            parameter.schema.clone().and_then(|schema| schema.get("default").map(|default| default.to_string()));
+          match parameter.r#in {
+            In::Query => &mut query_items,
+            In::Header => &mut header_items,
+            In::Path => &mut path_items,
+            In::Cookie => &mut cookie_items,
+          }
+          .push(ParameterItem {
+            name: parameter.name.clone(),
+            value,
+            required: parameter.required.unwrap_or(false),
+            schema: parameter.schema.clone(),
+          });
         });
-      });
 
       for (name, value) in &state.global_headers {
         if header_items.iter().any(|item: &ParameterItem| item.name.eq_ignore_ascii_case(name)) {

--- a/src/panes/request.rs
+++ b/src/panes/request.rs
@@ -83,11 +83,13 @@ impl RequestPane {
         if let Some(request_body) = &operation_item.operation.request_body {
           let mut bodies = serde_json::Map::new();
 
-          request_body.resolve(&state.openapi_spec).unwrap().content.iter().for_each(|(media_type, media)| {
-            if let Some(schema) = &media.schema {
-              bodies.insert(media_type.clone(), schema.clone());
-            }
-          });
+          if let Ok(request_body) = request_body.resolve(&state.openapi_spec) {
+            request_body.content.iter().for_each(|(media_type, media)| {
+              if let Some(schema) = &media.schema {
+                bodies.insert(media_type.clone(), schema.clone());
+              }
+            });
+          }
 
           push_schema!(bodies, "Body", "body");
         }
@@ -95,16 +97,21 @@ impl RequestPane {
         let mut header_parameters = serde_json::Map::new();
         let mut path_parameters = serde_json::Map::new();
         let mut cookie_parameters = serde_json::Map::new();
-        operation_item.operation.parameters.iter().flatten().for_each(|parameter_or_ref| {
-          let parameter = parameter_or_ref.resolve(&state.openapi_spec).unwrap();
-          match parameter.r#in {
-            In::Query => &mut query_parameters,
-            In::Header => &mut header_parameters,
-            In::Path => &mut path_parameters,
-            In::Cookie => &mut cookie_parameters,
-          }
-          .insert(parameter.name.clone(), parameter.schema.as_ref().unwrap_or(&serde_json::Value::Null).clone());
-        });
+        operation_item
+          .operation
+          .parameters
+          .iter()
+          .flatten()
+          .filter_map(|parameter_or_ref| parameter_or_ref.resolve(&state.openapi_spec).ok())
+          .for_each(|parameter| {
+            match parameter.r#in {
+              In::Query => &mut query_parameters,
+              In::Header => &mut header_parameters,
+              In::Path => &mut path_parameters,
+              In::Cookie => &mut cookie_parameters,
+            }
+            .insert(parameter.name.clone(), parameter.schema.as_ref().unwrap_or(&serde_json::Value::Null).clone());
+          });
 
         push_schema!(query_parameters, "Query", "query");
         push_schema!(header_parameters, "Header", "header");
@@ -240,5 +247,45 @@ impl Pane for RequestPane {
     );
 
     Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use openapi_31::v31::Openapi;
+  use serde_json::json;
+
+  use super::*;
+  use crate::state::{OperationItem, State};
+
+  #[test]
+  fn init_schema_skips_unresolvable_parameter_ref() {
+    let spec: Openapi = serde_json::from_value(json!({
+      "openapi": "3.1.0",
+      "info": { "title": "t", "version": "1" },
+      "paths": {
+        "/items": {
+          "get": {
+            "parameters": [{ "$ref": "#/components/schemas/Missing" }],
+            "responses": {}
+          }
+        }
+      }
+    }))
+    .unwrap();
+    let openapi_operations = spec
+      .into_operations()
+      .map(|(path, method, operation)| OperationItem { path, method, operation, ..Default::default() })
+      .collect();
+    let openapi_spec = serde_json::from_value(json!({
+      "openapi": "3.1.0",
+      "info": { "title": "t", "version": "1" },
+      "paths": {}
+    }))
+    .unwrap();
+    let state = State { openapi_operations, openapi_spec, ..Default::default() };
+
+    let mut pane = RequestPane::new(false, Style::default());
+    assert!(pane.init(&state).is_ok());
   }
 }


### PR DESCRIPTION
When an operation has a parameter or request body `$ref` that cannot be resolved (e.g. it points at the wrong component section, yielding `MismatchedRef`), `RequestPane::init_schema` and `ParameterEditor::init_parameters` would call `.unwrap()` and crash the whole TUI; this skips those refs the same way `response.rs` and `body_editor.rs` already do. Closes #42.