### PR TITLE
feat(cli): support `--input -` to load OpenAPI spec from stdin

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,7 +9,7 @@ pub struct Cli {
     short,
     long,
     value_name = "PATH",
-    help = "Input file or url, in json or yaml format with openapi specification"
+    help = "Input file path, URL, or `-` to read from stdin (json or yaml openapi spec)"
   )]
   pub input: String,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,10 +1,12 @@
 use std::{
   collections::{HashMap, HashSet},
   env,
+  io::IsTerminal,
 };
 
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{eyre, Result};
 use openapi_31::v31::{Openapi, Operation, Server};
+use tokio::io::AsyncReadExt;
 
 use crate::response::Response;
 
@@ -107,7 +109,50 @@ impl State {
     })
   }
 
+  async fn from_stdin() -> Result<Self> {
+    // Guard against the user typing `openapi-tui --input -` without piping
+    // anything; without this the process silently waits for them to type a
+    // full spec + Ctrl-D, which looks like a hang.
+    if std::io::stdin().is_terminal() {
+      return Err(eyre!("--input - expects an OpenAPI spec piped to stdin (got a TTY)"));
+    }
+
+    let mut buffer = String::new();
+    tokio::io::stdin().read_to_string(&mut buffer).await?;
+
+    if buffer.trim().is_empty() {
+      return Err(eyre!("--input - received no data on stdin"));
+    }
+
+    let openapi_spec = serde_yaml::from_str::<Openapi>(buffer.as_str())?;
+    let openapi_operations = openapi_spec
+      .into_operations()
+      .map(|(path, method, operation)| {
+        if path.starts_with('/') {
+          OperationItem { path, method, operation, r#type: OperationItemType::Path }
+        } else {
+          OperationItem { path, method, operation, r#type: OperationItemType::Webhook }
+        }
+      })
+      .collect::<Vec<_>>();
+    Ok(Self {
+      openapi_spec,
+      openapi_input_source: "<stdin>".to_string(),
+      openapi_operations,
+      active_operation_index: 0,
+      active_tag_name: None,
+      active_filter: String::default(),
+      input_mode: InputMode::Normal,
+      responses: HashMap::default(),
+      pending_operations: HashSet::default(),
+      spinner_frame: 0,
+    })
+  }
+
   pub async fn from_input(input: String) -> Result<Self> {
+    if input == "-" {
+      return State::from_stdin().await;
+    }
     if let Ok(url) = reqwest::Url::parse(input.as_str()) {
       State::from_url(url).await
     } else {


### PR DESCRIPTION
Adds a third dispatch branch in State::from_input: when input is the single dash, read the spec from stdin via tokio::io::stdin and parse through the existing serde_yaml pipeline (handles both YAML and JSON). Enables pipelines like:

  curl -fsSL https://example.com/openapi.json | openapi-tui --input -
  cat petstore.json | openapi-tui --input -

If stdin is a TTY (user typed `openapi-tui --input -` without piping), bail with a clear error rather than silently waiting for the user to type a full spec + Ctrl-D. Empty input also surfaces a clear error.

`openapi_input_source` is set to `<stdin>` for display purposes. The CLI help text is updated to mention the dash form.

Crossterm reads keys from /dev/tty directly on Unix, so the stdin pipe used for the spec doesn't conflict with keyboard input.